### PR TITLE
Add gettext so envsubst is available

### DIFF
--- a/src/docker/Dockerfile
+++ b/src/docker/Dockerfile
@@ -34,6 +34,7 @@ RUN dnf install -y \
   container-selinux \
   gcc \
   gcc-c++ \
+  gettext \
   git \
   jq \
   libffi-devel \


### PR DESCRIPTION
## what/why

- Add the gettext library so `envsubst` is available to use