### PR TITLE
Add golang and golangci-lint

### DIFF
--- a/spec/golang_spec.sh
+++ b/spec/golang_spec.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env shellspec
+
+Describe "printVersion()"
+  printVersion() {
+    go version | grep "${GO_VERSION}"
+  }
+
+  It "validates tool is installed by checking version"
+    When call printVersion
+    The output should include "${GO_VERSION}"
+    The status should eq 0
+  End
+End

--- a/spec/golangci_lint_spec.sh
+++ b/spec/golangci_lint_spec.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env shellspec
+
+Describe "printVersion()"
+  printVersion() {
+    golangci-lint --version | grep "${GOLANGCI_LINT_VERSION}"
+  }
+
+  It "validates tool is installed by checking version"
+    When call printVersion
+    The output should include "${GOLANGCI_LINT_VERSION}"
+    The status should eq 0
+  End
+End

--- a/src/docker/Dockerfile
+++ b/src/docker/Dockerfile
@@ -276,6 +276,22 @@ RUN asdf plugin add helm-cr \
   && asdf global helm-cr "${CHART_RELEASER_VERSION}" \
   && rm -rf /var/tmp/* /tmp/* /var/tmp/.???* /tmp/.???*
 
+# Install golang. Get versions using 'asdf list all golang'
+ARG GO_VERSION="1.15.6"
+ENV GO_VERSION=${GO_VERSION}
+RUN asdf plugin-add golang https://github.com/kennyp/asdf-golang.git \
+  && asdf install golang "${GO_VERSION}" \
+  && asdf global golang "${GO_VERSION}" \
+  && rm -rf /var/tmp/* /tmp/* /var/tmp/.???* /tmp/.???*
+
+# Install golangci-lint. Get versions using asdf list all golangci-lint
+ARG GOLANGCI_LINT_VERSION="1.34.1"
+ENV GOLANGCI_LINT_VERSION=${GOLANGCI_LINT_VERSION}
+RUN asdf plugin add golangci-lint https://github.com/hypnoglow/asdf-golangci-lint.git \
+  && asdf install golangci-lint "${GOLANGCI_LINT_VERSION}" \
+  && asdf global golangci-lint "${GOLANGCI_LINT_VERSION}" \
+  && rm -rf /var/tmp/* /tmp/* /var/tmp/.???* /tmp/.???*
+
 # Install goreleaser. Get versions using 'asdf list all goreleaser'
 ARG GORELEASER_VERSION="0.151.1"
 ENV GORELEASER_VERSION=${GORELEASER_VERSION}

--- a/src/docker/Dockerfile
+++ b/src/docker/Dockerfile
@@ -129,6 +129,7 @@ RUN wget -O /usr/local/bin/docker-compose "https://github.com/docker/compose/rel
 RUN useradd -ms /bin/bash anvil
 
 USER anvil
+WORKDIR /home/anvil
 
 # Install asdf. Get versions from https://github.com/asdf-vm/asdf/releases
 ARG ASDF_VERSION="0.7.8"


### PR DESCRIPTION
## what/why

- Add golang and golangci-lint, so we can use Anvil for golang projects