### PR TITLE
Feature/update kubectl versions

### DIFF
--- a/spec/kubectl_spec.sh
+++ b/spec/kubectl_spec.sh
@@ -17,11 +17,12 @@ Describe "getInstalledVersions()"
     asdf list kubectl
   }
 
-  It "validates 1.16, 1.17, and 1.18 is installed"
+  It "validates 1.17, 1.18, 1.19, and 1.20 are installed"
     When call listInstalledVersions
-    The output should include "1.16."
     The output should include "1.17."
     The output should include "1.18."
+    The output should include "1.19."
+    The output should include "1.20."
     The status should eq 0
   End
 End

--- a/src/docker/Dockerfile
+++ b/src/docker/Dockerfile
@@ -203,8 +203,8 @@ RUN asdf plugin add kubectl \
   && asdf install kubectl "$(asdf list all kubectl 1.17 | tail -1)" \
   && asdf install kubectl "$(asdf list all kubectl 1.19 | tail -1)" \
   && asdf install kubectl "$(asdf list all kubectl 1.20 | tail -1)" \
-  && asdf install kubectl "${KUBECTL_VERSION}" \
-  && asdf global kubectl "${KUBECTL_VERSION}" \
+  && asdf install kubectl "$(asdf list all kubectl ${KUBECTL_VERSION} | tail -1)" \
+  && asdf global kubectl "$(asdf list all kubectl ${KUBECTL_VERSION} | tail -1)" \
   && rm -rf /var/tmp/* /tmp/* /var/tmp/.???* /tmp/.???*
 
 # Install Helm. Get versions using 'asdf list all helm'.

--- a/src/docker/Dockerfile
+++ b/src/docker/Dockerfile
@@ -197,7 +197,7 @@ RUN asdf plugin add java \
 # Multiple versions of kubectl are installed. You can choose which one to use by using 'asdf local kubectl X.Y.Z'.
 # It will create a file called '.tool-versions' that asdf will look for.
 # The env var KUBECTL_VERSION is used to set the global version of kubectl.
-ARG KUBECTL_VERSION="1.18.0"
+ARG KUBECTL_VERSION="1.18"
 ENV KUBECTL_VERSION=${KUBECTL_VERSION}
 RUN asdf plugin add kubectl \
   && asdf install kubectl "$(asdf list all kubectl 1.17 | tail -1)" \

--- a/src/docker/Dockerfile
+++ b/src/docker/Dockerfile
@@ -200,8 +200,9 @@ RUN asdf plugin add java \
 ARG KUBECTL_VERSION="1.18.0"
 ENV KUBECTL_VERSION=${KUBECTL_VERSION}
 RUN asdf plugin add kubectl \
-  && asdf install kubectl "$(asdf list all kubectl 1.16 | tail -1)" \
   && asdf install kubectl "$(asdf list all kubectl 1.17 | tail -1)" \
+  && asdf install kubectl "$(asdf list all kubectl 1.19 | tail -1)" \
+  && asdf install kubectl "$(asdf list all kubectl 1.20 | tail -1)" \
   && asdf install kubectl "${KUBECTL_VERSION}" \
   && asdf global kubectl "${KUBECTL_VERSION}" \
   && rm -rf /var/tmp/* /tmp/* /var/tmp/.???* /tmp/.???*


### PR DESCRIPTION
## what
* Don't attempt to install kubectl version 1.16.x
* Do install kubectl versions 1.19.x and 1.20.x
* Install kubectl 1.18.x (latest patch) instead of 1.18.0
* Update the kubectl ShellSpec test appropriately

## why
* The asdf plugin no longer supports kubectl 1.16.x; this was causing the ShellSpec tests to fail.

## references
* Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
* Closes #16 