### PR TITLE
Remove v prefix from TERRAFORM_DOCS_VERSION

### DIFF
--- a/src/docker/Dockerfile
+++ b/src/docker/Dockerfile
@@ -246,7 +246,7 @@ RUN asdf plugin add terraform \
   && rm -rf /var/tmp/* /tmp/* /var/tmp/.???* /tmp/.???*
 
 # Install terraform-docs. Get versions using 'asdf list all terraform-docs'
-ARG TERRAFORM_DOCS_VERSION="v0.9.1"
+ARG TERRAFORM_DOCS_VERSION="0.9.1"
 ENV TERRAFORM_DOCS_VERSION=${TERRAFORM_DOCS_VERSION}
 RUN asdf plugin add terraform-docs \
   && asdf install terraform-docs "${TERRAFORM_DOCS_VERSION}" \


### PR DESCRIPTION
## what
* Changed the version of Terraform Docs that is installed from `v0.9.1` to `0.9.1` so that `asdf install` would succeed.

## why
* The terraform-docs plugin for `asdf` appears to have updated its versions to drop the `v` prefix, so the install was failing.

## references
* Closes #18 