### PR TITLE
Update terraform version

### DIFF
--- a/src/docker/Dockerfile
+++ b/src/docker/Dockerfile
@@ -257,7 +257,7 @@ RUN asdf plugin add helmfile \
   && rm -rf /var/tmp/* /tmp/* /var/tmp/.???* /tmp/.???*
 
 # Install Terraform. Get versions using 'asdf list all terraform'
-ARG TERRAFORM_VERSION="0.12.29"
+ARG TERRAFORM_VERSION="0.13.7"
 ENV TERRAFORM_VERSION=${TERRAFORM_VERSION}
 RUN asdf plugin add terraform \
   && asdf install terraform "${TERRAFORM_VERSION}" \


### PR DESCRIPTION
## what
* Anvil's Terraform is updated to version `0.13.7`

## why
* This is the new version of terraform we are using for cluster deployments

## references
* N/A
