### PR TITLE
Fix GPG issue when installing Terraform

### DIFF
--- a/src/docker/Dockerfile
+++ b/src/docker/Dockerfile
@@ -10,10 +10,6 @@ WORKDIR /
 # Need root to do rooty things
 USER root
 
-# Bust the whole docker cache so ASDF doesn't try to use the old Terraform signing key that doesn't work anymore
-# This line should be removed after we get a clean tagged release
-RUN echo "hello world"
-
 # Install containerd.io. Get versions from https://download.docker.com/linux/centos/7/x86_64/stable/Packages/
 # This must be installed manually because Red Hat has blocked later versions of containerd.io
 # from being installed normally on RHEL/CentOS 8. Their intention is for people to use Podman/Buildah,
@@ -32,7 +28,6 @@ ENV DOCKER_VERION=${DOCKER_VERSION}
 # shouldn't ever need version pinning
 # Please keep the list alphabetized for maintainability
 
-
 RUN dnf install -y --refresh \
   bind-utils \
   bzip2 \
@@ -49,6 +44,7 @@ RUN dnf install -y --refresh \
   make \
   ncurses-devel \
   openssl-devel \
+  perl-Digest-SHA \
   readline-devel \
   sqlite-devel \
   unixODBC-devel \

--- a/src/docker/Dockerfile
+++ b/src/docker/Dockerfile
@@ -10,6 +10,10 @@ WORKDIR /
 # Need root to do rooty things
 USER root
 
+# Bust the whole docker cache so ASDF doesn't try to use the old Terraform signing key that doesn't work anymore
+# This line should be removed after we get a clean tagged release
+RUN echo "hello world"
+
 # Install containerd.io. Get versions from https://download.docker.com/linux/centos/7/x86_64/stable/Packages/
 # This must be installed manually because Red Hat has blocked later versions of containerd.io
 # from being installed normally on RHEL/CentOS 8. Their intention is for people to use Podman/Buildah,


### PR DESCRIPTION
## what/why
- Fix GPG issue when installing Terraform by installing the perl package that contains the tool `shasum`

## references
- https://venturebeat.com/2021/04/26/hashicorp-revoked-private-key-exposed-in-codecov-security-breach/
