### PR TITLE
feature/sfs-1358-check-for-updates

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -36,6 +36,16 @@ tasks:
     cmds:
       - docker run --rm -v $(pwd):/workdir -w /workdir {{.FULLY_QUALIFIED_IMAGE_NAME}}:{{.TAG}} shellspec
 
+  updates:
+    desc: Run automated check for updates
+    vars:
+      TAG: '{{ coalesce .TAG "<no value>" }}'
+    preconditions:
+      - sh: test "{{.TAG}}" != "<no value>"
+        msg: Required variable 'TAG' not set
+    cmds:
+      - docker run --rm -v $(pwd):/workdir -w /workdir {{.FULLY_QUALIFIED_IMAGE_NAME}}:{{.TAG}} shellspec updates
+
   codefresh:test:
     cmds:
       - shellspec

--- a/lib_updates
+++ b/lib_updates
@@ -1,0 +1,37 @@
+#!/usr/bin/env shellspec
+
+# Check DNF for an update to the given package
+# Inputs: package to check for an update, e.g. "container.io"
+# Return: 0 if an update is availabe; non-0 if no update is available
+checkForDnfUpdate() {
+  dnf list updates 2>&1 | grep "^$*" > /dev/null
+}
+
+# Get the latest release from a GitHub project
+# Inputs: owner and repo of the GitHub project to check, e.g. "docker/compose"
+# Output: String containing the latest release version, e.g. "0.1.2"
+getLatestGitHubRelease() {
+    curl -H "Accept: application/vnd.github.v3+json" \
+      "https://api.github.com/repos/"$*"/releases" 2> /dev/null | \
+      jq '.[0].name' 2> /dev/null
+}
+
+# Get the latest tag from a GitHub project
+# Inputs: owner and repo of the GitHub project to check, e.g. "docker/compose"
+# Output: String containing the latest tag version, e.g. "0.1.2"
+getLatestGitHubTag() {
+    curl -H "Accept: application/vnd.github.v3+json" \
+      "https://api.github.com/repos/"$*"/tags" 2> /dev/null | \
+      jq '.[0].name' 2> /dev/null
+}
+
+# Check pip for an update to the given package
+# Inputs: package to check for an update, e.g. "awscli"
+# Return: 0 if an update is availabe; non-0 if no update is available
+checkForPipUpdate() {
+  pip list --outdated 2> /dev/null | grep "^$*" > /dev/null
+}
+
+getLatestVersionFromAsdf() {
+  asdf latest $* 2> /dev/null
+}

--- a/lib_updates
+++ b/lib_updates
@@ -7,6 +7,13 @@ checkForDnfUpdate() {
   dnf list updates 2>&1 | grep "^$*" > /dev/null
 }
 
+# Gets latest release from DNF
+# Inputs: package to check for an update, e.g. "skopeo.x86_64"
+# Return: String containing the latest release version, e.g. "0.1.2"
+getLatestVersionFromDnf() {
+  dnf list updates 2> /dev/null | grep "$*" 2> /dev/null | awk '{print $2}' 2> /dev/null
+}
+
 # Get the latest release from a GitHub project
 # Inputs: owner and repo of the GitHub project to check, e.g. "docker/compose"
 # Output: String containing the latest release version, e.g. "0.1.2"
@@ -32,6 +39,31 @@ checkForPipUpdate() {
   pip list --outdated 2> /dev/null | grep "^$*" > /dev/null
 }
 
+# Get latest version of an update from Pip
+# Inputs: package to check for an update, e.g. "pipenv"
+# Return: String containing the latest version, e.g. "0.1.2"
+getLatestVersionFromPip() {
+  pip list --outdated 2> /dev/null | grep "$*" 2> /dev/null | awk '{print $3}' 2> /dev/null
+}
+
+# Get the latest version from asdf
+# Input: name of the package, e.g. "terraform"
+# Return: String containing the latest version, e.g. "0.1.2"
 getLatestVersionFromAsdf() {
   asdf latest $* 2> /dev/null
+}
+
+# Get the latest version from asdf list
+# Some packages are not supported with asdf latest
+# Input: name of the package, e.g. "java"
+# Return: String containing the latest version, e.g. "0.1.2"
+getLatestVersionFromAsdfList() {
+  asdf list $* 2> /dev/null
+}
+
+# Get the latest version from npm
+# Inputs: name of the package, e.g. "serverless"
+# Return: String containing the latest version, e.g. "0.1.2"
+getLatestVersionFromNpm() {
+  npm show $* version 2> /dev/null
 }

--- a/src/docker/Dockerfile
+++ b/src/docker/Dockerfile
@@ -21,7 +21,7 @@ ENV CONTAINERD_VERSION=${CONTAINERD_VERSION}
 
 # Specify Docker version to install. Get versions using 'dnf list docker-ce --showduplicates | sort -r'
 ARG DOCKER_VERSION="3:19.03.13"
-ENV DOCKER_VERION=${DOCKER_VERSION}
+ENV DOCKER_VERSION=${DOCKER_VERSION}
 
 # Intentionally do not specify versions for the tools in the Development Tools group and other
 # base packages, so that we always get the latest version. These packages are very stable and

--- a/updates/asdf_spec.sh
+++ b/updates/asdf_spec.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env shellspec
+
+Describe "Check for an update to asdf"
+  Include ./lib_updates
+  It "validates tool is up-to-date by checking for an update"
+    When call getLatestGitHubTag asdf-vm/asdf
+    The output should include "${ASDF_VERSION}"
+    The status should eq 0
+  End
+End

--- a/updates/asdf_spec.sh
+++ b/updates/asdf_spec.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env shellspec
 
-Describe "Check for an update to asdf"
+Describe "Check for an asdf update"
   Include ./lib_updates
-  It "validates tool is up-to-date by checking for an update"
+  It "validates asdf is up-to-date via GitHub"
     When call getLatestGitHubTag asdf-vm/asdf
     The output should include "${ASDF_VERSION}"
     The status should eq 0

--- a/updates/aws_cli_spec.sh
+++ b/updates/aws_cli_spec.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env shellspec
+
+Describe "Check for a AWS CLI update"
+  Include ./lib_updates
+  It "validates AWS CLI is up-to-date via pip"
+    When call getLatestVersionFromPip awscli
+    The output should include "${AWS_CLI_VERSION}"
+    The status should eq 0
+  End
+End

--- a/updates/chart_releaser_spec.sh
+++ b/updates/chart_releaser_spec.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env shellspec
+
+Describe "Check for Helm Chart Releaser update"
+  Include ./lib_updates
+  It "validates Helm Chart Releaser is up-to-date via asdf"
+    When call getLatestVersionFromAsdf helm-cr
+    The output should include "${CHART_RELEASER_VERSION}"
+    The status should eq 0
+  End
+End

--- a/updates/docker_compose_spec.sh
+++ b/updates/docker_compose_spec.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env shellspec
+
+Describe "Check for a Docker Compose update"
+  Include ./lib_updates
+  It "validates Docker Compose is up-to-date via GitHub"
+    When call getLatestGitHubTag docker/compose
+    The output should include "${DOCKER_COMPOSE_VERSION}"
+    The status should eq 0
+  End
+End

--- a/updates/docker_spec.sh
+++ b/updates/docker_spec.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env shellspec
 
-Describe "Check for an update to Docker"
+Describe "Check for a Docker update"
   Include ./lib_updates
-  It "validates tool is up-to-date by checking for an update"
+  It "checks DNF update list for Docker"
     When call checkForDnfUpdate docker-ce.x86_64
     The status should not eq 0
   End

--- a/updates/docker_spec.sh
+++ b/updates/docker_spec.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env shellspec
+
+Describe "Check for an update to Docker"
+  Include ./lib_updates
+  It "validates tool is up-to-date by checking for an update"
+    When call checkForDnfUpdate docker-ce.x86_64
+    The status should not eq 0
+  End
+End

--- a/updates/fossa_spec.sh
+++ b/updates/fossa_spec.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env shellspec
+
+Describe "Check for a Fossa update"
+  Include ./lib_updates
+  It "validates Fossa is up-to-date via GitHub"
+    When call getLatestGitHubRelease fossas/fossa-cli
+    The output should include "${FOSSA_VERSION}"
+    The status should eq 0
+  End
+End

--- a/updates/go_spec.sh
+++ b/updates/go_spec.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env shellspec
+
+Describe "Check for Go update"
+  Include ./lib_updates
+  It "validates Go is up-to-date via asdf"
+    When call getLatestVersionFromAsdf golang
+    The output should include "${GO_VERSION}"
+    The status should eq 0
+  End
+End

--- a/updates/go_task_spec.sh
+++ b/updates/go_task_spec.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env shellspec
+
+Describe "Check for a Go-Task update"
+  Include ./lib_updates
+  It "validates Go-Task is up-to-date via GitHub"
+    When call getLatestGitHubTag go-task/task
+    The output should include "${GO_TASK_VERSION}"
+    The status should eq 0
+  End
+End

--- a/updates/golangci_lint_spec.sh
+++ b/updates/golangci_lint_spec.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env shellspec
+
+Describe "Check for GolangCI Lint update"
+  Include ./lib_updates
+  It "validates GolangCI Lint is up-to-date via asdf"
+    When call getLatestVersionFromAsdf golangci-lint
+    The output should include "${GOLANGCI_LINT_VERSION}"
+    The status should eq 0
+  End
+End

--- a/updates/gomplate_spec.sh
+++ b/updates/gomplate_spec.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env shellspec
+
+Describe "Check for a Gomplate update"
+  Include ./lib_updates
+  It "validates Gomplate is up-to-date via GitHub"
+    When call getLatestGitHubTag hairyhenderson/gomplate
+    The output should include "${GOMPLATE_VERSION}"
+    The status should eq 0
+  End
+End

--- a/updates/goreleaser_spec.sh
+++ b/updates/goreleaser_spec.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env shellspec
+
+Describe "Check for Go Releaser update"
+  Include ./lib_updates
+  It "validates Go Releaser is up-to-date via asdf"
+    When call getLatestVersionFromAsdf goreleaser
+    The output should include "${GORELEASER_VERSION}"
+    The status should eq 0
+  End
+End

--- a/updates/hadolint_spec.sh
+++ b/updates/hadolint_spec.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env shellspec
+
+Describe "Check for a Hadolint update"
+  Include ./lib_updates
+  It "validates Hadolint is up-to-date via GitHub"
+    When call getLatestGitHubTag hadolint/hadolint
+    The output should include "${HADOLINT_VERSION}"
+    The status should eq 0
+  End
+End

--- a/updates/helm_diff_spec.sh
+++ b/updates/helm_diff_spec.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env shellspec
+
+Describe "Check for a Helm Diff update"
+  Include ./lib_updates
+  It "validates Helm Diff is up-to-date via GitHub"
+    When call getLatestGitHubTag databus23/helm-diff
+    The output should include "${HELM_DIFF_VERSION}"
+    The status should eq 0
+  End
+End

--- a/updates/helm_git_spec.sh
+++ b/updates/helm_git_spec.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env shellspec
+
+Describe "Check for a Helm Git update"
+  Include ./lib_updates
+  It "validates Helm Git is up-to-date via GitHub"
+    When call getLatestGitHubTag aslafy-z/helm-git
+    The output should include "${HELM_GIT_VERSION}"
+    The status should eq 0
+  End
+End

--- a/updates/helm_s3_spec.sh
+++ b/updates/helm_s3_spec.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env shellspec
+
+Describe "Check for a Helm S3 update"
+  Include ./lib_updates
+  It "validates Helm S3 is up-to-date via GitHub"
+    When call getLatestGitHubTag hypnoglow/helm-s3
+    The output should include "${HELM_S3_VERSION}"
+    The status should eq 0
+  End
+End

--- a/updates/helm_spec.sh
+++ b/updates/helm_spec.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env shellspec
+
+Describe "Check for Helm update"
+  Include ./lib_updates
+  It "validates Helm is up-to-date via asdf"
+    When call getLatestVersionFromAsdf helm
+    The output should include "${HELM_VERSION}"
+    The status should eq 0
+  End
+End

--- a/updates/helmfile_spec.sh
+++ b/updates/helmfile_spec.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env shellspec
+
+Describe "Check for Helmfile update"
+  Include ./lib_updates
+  It "validates Helmfile is up-to-date via asdf"
+    When call getLatestVersionFromAsdf helmfile
+    The output should include "${HELMFILE_VERSION}"
+    The status should eq 0
+  End
+End

--- a/updates/java_spec.sh
+++ b/updates/java_spec.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env shellspec
+
+Describe "Check for a Java update"
+  Include ./lib_updates
+  It "validates Java is up-to-date via asdf"
+    When call getLatestVersionFromAsdfList java
+    The output should include "${JAVA_VERSION}"
+    The status should eq 0
+  End
+End

--- a/updates/klar_spec.sh
+++ b/updates/klar_spec.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env shellspec
+
+Describe "Check for a Klar update"
+  Include ./lib_updates
+  It "validates Klar is up-to-date via GitHub"
+    When call getLatestGitHubRelease optiopay/klar
+    The output should include "${KLAR_VERSION}"
+    The status should eq 0
+  End
+End

--- a/updates/kubectl_spec.sh
+++ b/updates/kubectl_spec.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env shellspec
+
+Describe "Check for Kubectl update"
+  Include ./lib_updates
+  It "validates Kubectl is up-to-date via asdf"
+    When call getLatestVersionFromAsdf kubectl
+    The output should include "${KUBECTL_VERSION}"
+    The status should eq 0
+  End
+End

--- a/updates/maven_spec.sh
+++ b/updates/maven_spec.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env shellspec
+
+Describe "Check for Maven update"
+  Include ./lib_updates
+  It "validates Maven is up-to-date via asdf"
+    When call getLatestVersionFromAsdf maven
+    The output should include "${MAVEN_VERSION}"
+    The status should eq 0
+  End
+End

--- a/updates/nodejs_spec.sh
+++ b/updates/nodejs_spec.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env shellspec
+
+Describe "Check for Node.js update"
+Include ./lib_updates
+  It "validates tool is up-to-date by checking for an update"
+    When call getLatestVersionFromAsdf nodejs
+    The output should include "${NODEJS_VERSION}"
+    The status should eq 0
+  End
+End

--- a/updates/nodejs_spec.sh
+++ b/updates/nodejs_spec.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env shellspec
 
-Describe "Check for Node.js update"
-Include ./lib_updates
-  It "validates tool is up-to-date by checking for an update"
+Describe "Check for Node update"
+  Include ./lib_updates
+  It "validates Node is up-to-date via asdf"
     When call getLatestVersionFromAsdf nodejs
     The output should include "${NODEJS_VERSION}"
     The status should eq 0

--- a/updates/pipenv_spec.sh
+++ b/updates/pipenv_spec.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env shellspec
 
-Describe "Check for an update to Pipenv"
+Describe "Check for a Pipenv update"
   Include ./lib_updates
-  It "validates tool is up-to-date by checking for an update"
-    When call checkForPipUpdate pipenv
-    The status should not eq 0
+  It "validates Pipenv is up-to-date via pip"
+    When call getLatestVersionFromPip pipenv
+    The output should include "${PIPENV_VERSION}"
+    The status should eq 0
   End
 End

--- a/updates/pipenv_spec.sh
+++ b/updates/pipenv_spec.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env shellspec
+
+Describe "Check for an update to Pipenv"
+  Include ./lib_updates
+  It "validates tool is up-to-date by checking for an update"
+    When call checkForPipUpdate pipenv
+    The status should not eq 0
+  End
+End

--- a/updates/podman_spec.sh
+++ b/updates/podman_spec.sh
@@ -2,7 +2,7 @@
 
 Describe "Check for Podman update"
   Include ./lib_updates
-  It "gets the latest version of Docker"
+  It "gets the latest version of Podman"
     When call checkForDnfUpdate podman.x86_64
     The status should not eq 0
   End

--- a/updates/podman_spec.sh
+++ b/updates/podman_spec.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env shellspec
+
+Describe "Check for Podman update"
+  Include ./lib_updates
+  It "gets the latest version of Docker"
+    When call checkForDnfUpdate podman.x86_64
+    The status should not eq 0
+  End
+End

--- a/updates/pre_commit_spec.sh
+++ b/updates/pre_commit_spec.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env shellspec
+
+Describe "Check for a Pre-commit update"
+  Include ./lib_updates
+  It "validates Pre-commit is up-to-date via pip"
+    When call getLatestVersionFromPip pre-commit
+    The output should include "${PRE_COMMIT_VERSION}"
+    The status should eq 0
+  End
+End

--- a/updates/python_spec.sh
+++ b/updates/python_spec.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env shellspec
+
+Describe "Check for Python update"
+  Include ./lib_updates
+  It "validates Python is up-to-date via asdf"
+    When call getLatestVersionFromAsdf python
+    The output should include "${PYTHON_VERSION}"
+    The status should eq 0
+  End
+End

--- a/updates/serverless_spec.sh
+++ b/updates/serverless_spec.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env shellspec
+
+Describe "Check for Serverless update"
+  Include ./lib_updates
+  It "validates Serverless is up-to-date via npm"
+    When call getLatestVersionFromNpm serverless
+    The output should include "${SERVERLESS_VERSION}"
+    The status should eq 0
+  End
+End

--- a/updates/shellcheck_spec.sh
+++ b/updates/shellcheck_spec.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env shellspec
+
+Describe "Check for a Shellcheck update"
+  Include ./lib_updates
+  It "validates Shellcheck is up-to-date via GitHub"
+    When call getLatestGitHubTag koalaman/shellcheck
+    The output should include "${SHELLCHECK_VERSION}"
+    The status should eq 0
+  End
+End

--- a/updates/shellspec_spec.sh
+++ b/updates/shellspec_spec.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env shellspec
+
+Describe "Check for update to ShellSpec"
+  Include ./lib_updates
+  It "validates tool is up-to-date by checking for an update"
+    When call getLatestGitHubRelease shellspec/shellspec
+    The output should include "${SHELLSPEC_VERSION}"
+    The status should eq 0
+  End
+End

--- a/updates/shellspec_spec.sh
+++ b/updates/shellspec_spec.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env shellspec
 
-Describe "Check for update to ShellSpec"
+Describe "Check for update to Shellspec"
   Include ./lib_updates
-  It "validates tool is up-to-date by checking for an update"
+  It "validates Shellspec is up-to-date via GitHub"
     When call getLatestGitHubRelease shellspec/shellspec
     The output should include "${SHELLSPEC_VERSION}"
     The status should eq 0

--- a/updates/skopeo_spec.sh
+++ b/updates/skopeo_spec.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env shellspec
+
+Describe "Check for Skopeo update"
+  Include ./lib_updates
+  It "checks DNF update list for Skopeo"
+    When call checkForDnfUpdate skopeo.x86_64
+    The status should not eq 0
+  End
+End

--- a/updates/sonarscanner_spec.sh
+++ b/updates/sonarscanner_spec.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env shellspec
+
+Describe "Check for Sonarscanner update"
+  Include ./lib_updates
+  It "validates Sonarscanner is up-to-date via asdf"
+    When call getLatestVersionFromAsdf sonarscanner
+    The output should include "${SONARSCANNER_VERSION}"
+    The status should eq 0
+  End
+End

--- a/updates/terraform_docs_spec.sh
+++ b/updates/terraform_docs_spec.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env shellspec
+
+Describe "Check for Terraform Docs update"
+  Include ./lib_updates
+  It "validates Terraform Docs is up-to-date via asdf"
+    When call getLatestVersionFromAsdfList terraform-docs
+    The output should include "${TERRAFORM_DOCS_VERSION}"
+    The status should eq 0
+  End
+End

--- a/updates/terraform_spec.sh
+++ b/updates/terraform_spec.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env shellspec
+
+Describe "Check for Terraform update"
+  Include ./lib_updates
+  It "validates Terraform is up-to-date via asdf"
+    When call getLatestVersionFromAsdf terraform
+    The output should include "${TERRAFORM_VERSION}"
+    The status should eq 0
+  End
+End

--- a/updates/tflint_spec.sh
+++ b/updates/tflint_spec.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env shellspec
+
+Describe "Check for TFlint update"
+  Include ./lib_updates
+  It "validates TFlint is up-to-date via asdf"
+    When call getLatestVersionFromAsdfList tflint
+    The output should include "${TFLINT_VERSION}"
+    The status should eq 0
+  End
+End

--- a/updates/tfsec_spec.sh
+++ b/updates/tfsec_spec.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env shellspec
+
+Describe "Check for TFsec update"
+  Include ./lib_updates
+  It "validates TFsec is up-to-date via asdf"
+    When call getLatestVersionFromAsdfList tfsec
+    The output should include "${TFSEC_VERSION}"
+    The status should eq 0
+  End
+End


### PR DESCRIPTION
## what
Added shellspec unit tests for each package with a pinned version
* asdf
* aws-cli
* docker-compose
* docker
* fossa
* go
* go task
* golangci-lint
* gomplate
* goreleaser
* hadolint
* helm-diff
* helm-git
* helm-s3
* helm
* helm chart releaser
* helmfile
* java
* klar
* kubectl
* maven
* nodejs
* pipenv
* podman
* pre-commit
* python
* serverless
* shellcheck
* shellspec
* skopeo
* sonarscanner
* terraform-docs
* terraform
* tflint
* tfsec

## why
* Automated discovery of latest versions for each package

## references
* [SFS-1358](https://jira.devops.saicwebhost.net/browse/SFS-1358)
* [Design Document](https://gitlab.sif.saicdevops.com/team-vulcan/documents/-/blob/feature/SFS-1358-anvil-tool-versions/design-documents/SFS-1358-Discovery-of-Anvil-tool-versions.md)
