### PR TITLE
Update serverless to 3.3.0

### DIFF
--- a/src/docker/Dockerfile
+++ b/src/docker/Dockerfile
@@ -364,7 +364,7 @@ RUN asdf plugin-add sonarscanner https://github.com/virtualstaticvoid/asdf-sonar
   && rm -rf /var/tmp/* /tmp/* /var/tmp/.???* /tmp/.???*
 
 # Install serverless. Get versions from https://github.com/serverless/serverless/releases
-ARG SERVERLESS_VERSION="2.54.0"
+ARG SERVERLESS_VERSION="3.3.0"
 ENV SERVERLESS_VERSION=${SERVERLESS_VERSION}
 RUN npm install -g serverless@${SERVERLESS_VERSION} \
   && rm -rf /var/tmp/* /tmp/* /var/tmp/.???* /tmp/.???*


### PR DESCRIPTION
## what
* Updating Serverless framework from 2.54.0 to 3.3.0

## why
* We'd like to use the new features within 3.3.0 and this will help with setting globally in pipelines without additional npm installation commands
